### PR TITLE
fix(appointments): Correct column name for meeting link

### DIFF
--- a/backend/calendar.js
+++ b/backend/calendar.js
@@ -14,6 +14,10 @@ export const oAuth2Client = new google.auth.OAuth2(
 )
 
 // Store token after user authorizes
+// IMPORTANT: This is a short-term, in-memory token store. If the server restarts,
+// the token will be lost and re-authorization will be required. For a production
+// environment, it is highly recommended to store the refresh token in a secure
+// database and use it to generate new access tokens as needed.
 let TOKEN = null
 
 export function setOAuthToken(token) {

--- a/src/pages/Appointment.js
+++ b/src/pages/Appointment.js
@@ -801,7 +801,7 @@ const Appointment = () => {
 							if (meetLink) {
 								const { error: updateError } = await supabase
 									.from('Appointment')
-									.update({ "meeting_link": meetLink })
+									.update({ "meet_link": meetLink })
 									.eq('id', appointmentRow.id);
 
 								if (updateError) {
@@ -809,7 +809,7 @@ const Appointment = () => {
 								}
 
 								// Also update the local state for the success screen
-								appointmentRow.meeting_link = meetLink;
+								appointmentRow.meet_link = meetLink;
 								console.log("✅ Appointment updated with meeting link.");
 							}
 

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -271,9 +271,9 @@ const AppointmentList = ({ appointments }) => {
 						</div>
 					</div>
 					<div className="text-right w-full sm:w-auto">
-						{appt.consultationMethod === 'online' && appt.meeting_link ? (
+						{appt.consultationMethod === 'online' && appt.meet_link ? (
 							<a
-								href={appt.meeting_link}
+								href={appt.meet_link}
 								target="_blank"
 								rel="noopener noreferrer"
 								className="inline-block px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-semibold shadow-md transition-all hover:shadow-lg flex items-center gap-2"


### PR DESCRIPTION
- Updated 'meeting_link' to 'meet_link' in `Appointment.js` to ensure the Google Meet link is correctly saved to the Supabase 'Appointment' table after being generated.
- Updated 'meeting_link' to 'meet_link' in `Dashboard.js` to ensure the 'Join Meeting' button appears correctly for users.
- Added a comment to `backend/calendar.js` to warn about the fragile in-memory token storage and recommend a more robust solution for future development.